### PR TITLE
Update Dockerfile to use newer GoLang (#87)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.21.3 AS trivy_builder
+FROM docker.io/golang:1.22.5 AS trivy_builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
Newer Go library(ies) allows building newer versions of Picard.